### PR TITLE
Update pyinstaller.txt

### DIFF
--- a/pyinstaller.txt
+++ b/pyinstaller.txt
@@ -4,6 +4,7 @@
 
 sudo pip3 install pyinstaller
 
+cp src/jpeg-9c-win/Include/jpegint.h /$anaconda path$/include
 python3 setup.py build
 pyinstaller hstego-linux.spec
 


### PR DESCRIPTION
For the Linux operating system, you need to copy the jpegint.h file to include, otherwise an error will appear when gcc compiles the code "src/jpeg_toolbox_extension.c:6:10: fatal error: jpegint.h: No such file or directory"