### PR TITLE
Make hstego compatible with JPEG_LIB_VERSION <= 62

### DIFF
--- a/src/jpeg_toolbox_extension.c
+++ b/src/jpeg_toolbox_extension.c
@@ -194,9 +194,17 @@ LIBRARY_API PyObject* read_file(const char *path)
    result = dict_add_int(result, "X_density", cinfo.X_density);
    result = dict_add_int(result, "Y_density", cinfo.Y_density);
    result = dict_add_int(result, "density_unit", cinfo.density_unit);
+
+#if JPEG_LIB_VERSION >= 80
    result = dict_add_int(result, "block_size", cinfo.block_size);
+#endif
+
+#if JPEG_LIB_VERSION >= 70
    result = dict_add_int(result, "min_DCT_h_scaled_size", cinfo.min_DCT_h_scaled_size);
    result = dict_add_int(result, "min_DCT_v_scaled_size", cinfo.min_DCT_v_scaled_size);
+#else
+   result = dict_add_int(result, "min_DCT_scaled_size", cinfo.min_DCT_scaled_size);
+#endif
    // }}}
 
    // {{{ Components info
@@ -216,8 +224,13 @@ LIBRARY_API PyObject* read_file(const char *path)
       comp = dict_add_int(comp, "dc_tbl_no", cinfo.comp_info[ci].dc_tbl_no);
 
       jpeg_component_info *compptr = cinfo.comp_info + ci;
+
+#if JPEG_LIB_VERSION >= 70
       comp = dict_add_int(comp, "DCT_h_scaled_size", compptr->DCT_h_scaled_size);
       comp = dict_add_int(comp, "DCT_v_scaled_size", compptr->DCT_v_scaled_size);
+#else
+      comp = dict_add_int(comp, "DCT_scaled_size", compptr->DCT_scaled_size);
+#endif
 
       PyList_Append(comp_info, comp);
       Py_DecRef(comp);
@@ -472,9 +485,15 @@ LIBRARY_API void write_file(PyObject *data, const char *path)
    cinfo.X_density = dict_get_int(data, "X_density");
    cinfo.Y_density = dict_get_int(data, "Y_density");
    cinfo.density_unit = dict_get_int(data, "density_unit");
+
+#if JPEG_LIB_VERSION >= 80
    cinfo.block_size = dict_get_int(data, "block_size");
+#endif
+
+#if JPEG_LIB_VERSION >= 70
    cinfo.min_DCT_h_scaled_size = dict_get_int(data, "min_DCT_h_scaled_size");
    cinfo.min_DCT_v_scaled_size = dict_get_int(data, "min_DCT_v_scaled_size");
+#endif
 
    //cinfo.optimize_coding = dict_get_int(data, "optimize_coding"); XXX
    cinfo.num_components = dict_get_int(data, "jpeg_components");
@@ -497,8 +516,13 @@ LIBRARY_API void write_file(PyObject *data, const char *path)
       cinfo.comp_info[ci].dc_tbl_no = dict_get_int(item, "dc_tbl_no");
 
       jpeg_component_info *compptr = cinfo.comp_info + ci;
+
+#if JPEG_LIB_VERSION >= 70
       compptr->DCT_h_scaled_size = dict_get_int(item, "DCT_h_scaled_size");
       compptr->DCT_v_scaled_size = dict_get_int(item, "DCT_v_scaled_size");
+#else
+      compptr->DCT_scaled_size = dict_get_int(item, "DCT_scaled_size");
+#endif
    }
 
 


### PR DESCRIPTION
Fedora ships libjpeg-turbo as a replacement for libjpeg: https://fedoraproject.org/wiki/Features/libjpeg-turbo

The latest versions shipped by Fedora Linux 36 are as follows:
libjpeg-turbo.i686          2.1.2-2.fc36
libjpeg-turbo.x86_64        2.1.2-2.fc36
libjpeg-turbo-devel.x86_64  2.1.2-2.fc36
libjpeg-turbo-utils.x86_64  2.1.2-2.fc36

Above version of libjpeg-turbo #define's JPEG_LIB_VERSION to 62 in /usr/include/jconfig-64.h, which is consistent with official rpms distributed by upstream.

Ubuntu however supplies v8 of the libjpeg-turbo ABI, which has been considered by Fedora as well, but hasn't been done yet: https://fedoraproject.org/wiki/Features/libjpeg-turbo-jpeg8-ABI

Therefore, the safe way to include features such as:
    struct jpeg_compress_struct.min_DCT_h_scaled_size
    struct jpeg_compress_struct.min_DCT_v_scaled_size

    struct jpeg_decompress_struct.min_DCT_h_scaled_size
    struct jpeg_decompress_struct.min_DCT_v_scaled_size
    struct jpeg_decompress_struct.block_size
is to wrap them in #if-guards as used in jpeglib.h: https://github.com/libjpeg-turbo/libjpeg-turbo/blob/main/jpeglib.h#L417 https://github.com/libjpeg-turbo/libjpeg-turbo/blob/main/jpeglib.h#L642 https://github.com/libjpeg-turbo/libjpeg-turbo/blob/main/jpeglib.h#L679