### PR TITLE
fix stego message embedding bug

### DIFF
--- a/hstegolib.py
+++ b/hstegolib.py
@@ -461,7 +461,7 @@ class S_UNIWARD:
         if n_channels == 1:
             msg_bits = [ message ] 
         else:
-            l = len(data)//3
+            l = len(message)//3
             msg_bits = [ message[:l], message[l:2*l], message[2*l:] ]
 
         for c in range(n_channels):
@@ -744,7 +744,7 @@ class J_UNIWARD:
         if n_channels == 1:
             msg_bits = [ message ] 
         else:
-            l = len(data)//3
+            l = len(message)//3
             msg_bits = [ message[:l], message[l:2*l], message[2*l:] ]
 
         for c in range(n_channels):


### PR DESCRIPTION
There is a logic error in HStego during the embedding phase. When dividing the payload into 3 parts to distribute across the color channels, the algorithm divides by the total data length instead of the actual message length. 

As a result, the third channel consistently ends up with an excess of 33 to 50 bytes compared to the first two channels. This extra data consists of:
Salt: 16 bytes (AES block size)
Cipher IV: 16 bytes
Padding: 0 to 16 bytes

This predictable byte imbalance allows an attacker to verify whether a guessed password is correct by extracting only the 32 bit of headers and checking the byte length differences between the channels, completely bypassing the need to perform a full aes decryption.

I have created a poc tool to demonstrate how this vulnerability can be exploited : 
https://github.com/ErikDervishi03/HStegoCracker